### PR TITLE
Enlève le lien vers le site Firefox en allemand dans le makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ build:
 	cp -r common/. firefox/data/
 
 	# For this to work, you need to install
-	# https://addons.mozilla.org/de/firefox/addon/autoinstaller/ for firefox
+	# https://addons.mozilla.org/firefox/addon/autoinstaller/ for firefox
 	cd firefox; jpm watchpost --post-url http://localhost:8888 
 


### PR DESCRIPTION
Juste un petit truc qui gossait dans le Makefile. On veut tout avoir en anglais, alors on devrait pas pointer vers un site en allemand.
