### PR TITLE
Version stable bouton pondération 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ safari/safari.safariextension/style.css
 safari/safari.safariextension/lib
 safari/safari.safariextension/addons
 safari/safari.safariextension/icon-*
+safari/safari.safariextension/safari/safari.xcodeproj/*

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Ainsi lorsqu'un changement est fait dans le dossier de firefox, l'extension va a
 
 Ajouter manuellement de la façon suivante :
 
-Safari —> Développement —> Afficher extension Builder —> + —> Ajouter une extension —> Sélectionner le répertoire contenant ".safariextension" comme extension —>  contenu injecté —> script de fin —> main.js —> feuille de style —> style.css —> installer
+Safari —> Développement —> Afficher extension Builder —> + —> Ajouter une extension —> Sélectionner le répertoire contenant ".safariextension" comme extension —>  contenu injecté —> script de fin —> main.js —> feuille de style —> style.css —> Installer
 
 Pour coder	 : Xcode 
 

--- a/safari/safari.safariextension/data_funtions.js
+++ b/safari/safari.safariextension/data_funtions.js
@@ -1,3 +1,5 @@
+/* Version 0.2 */
+
 var data_ponderation;
 var btn_ponderation;
 var pond_grid;
@@ -15,7 +17,7 @@ function addon_ponderation(){
     btn_ponderation.classList.add("gel-glacial");
     btn_ponderation.onclick = get_all_ponderation;
 
-	// Btns div
+	// Btn div
     var div_btn = document.createElement("div");
 	div_btn.id = "btn_ponderation";
     div_btn.classList.add("gel-glacial-bar");
@@ -28,13 +30,20 @@ function addon_ponderation(){
 // Get Ponderation datas from url ponderation
 function get_all_ponderation(){
 
+    // Change Note's div id
     document.getElementById("gridContainer4").id = "gridNotes";
-
+    document.getElementById("Loader").id = "LoaderNotes";
+    
+    // Disable btn for loading
     btn_ponderation.disabled = true;
-    btn_ponderation.innerHTML = "Load datas...";
+    btn_ponderation.innerHTML = "Telechargement...";
+    
+    // Set url to get data ponderation
     var url = window.location.href;
     url = url.replace("notesEtu.php", "ponderation.php");
-    $("#ponderation_grid").load(url,function(){
+    
+    // Get all data needed from ponderation page
+    $("#ponderation_grid").load(url ,function(){
         data_ponderation = data;
 		for (i = 0; i < data.length-1; i++) {
 			for (j = 0; j < countProperties(data[i])-1; j++) {
@@ -46,12 +55,59 @@ function get_all_ponderation(){
 					}
 				}
 			}
-		}
-        btn_ponderation.onclick = show_hide_ponderation;
-        btn_ponderation.disabled = false;
-        btn_ponderation.innerHTML = "Cacher grille des ponderations";
-        document.getElementById('ponderation_grid').setAttribute('style','display: block');
-	});
+		};
+        // Add listener when loading is complet
+        observe_loading();
+    });
+}
+
+// Observer Loading Page 0_0
+function observe_loading(){
+
+    // Observe when page will be all loaded (necessary)
+    var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutationRecord) {
+        
+            // At this point some cell's data remaining
+            observe_cells();
+            //console.log('Page ponderation finish loading');
+        });
+    });
+    
+    // Apply observer on target
+    document.getElementById('Loader').setAttribute('style','visibility: visible;');
+    var target = document.getElementById('Loader');
+    observer.observe(target, { attributes : true, attributeFilter : ['style'] });
+}
+
+// Observe Grid Finish Loading 0_0
+function observe_cells(){
+
+    // Observe when page will be all loaded (necessary)
+    var observer = new MutationObserver(function(mutations) {
+        mutations.forEach(function(mutationRecord) {
+            // Keep only grid
+            keep_grid_only();
+            // Reset btn
+            btn_ponderation.onclick = show_hide_ponderation;
+            btn_ponderation.disabled = false;
+            // Hide grid
+            show_hide_ponderation();
+            //console.log('Grid ponderation finish loading');
+        });
+    });
+    
+    // Apply target
+    jQuery('#gridContainer4').find('.dojoxGridMasterView').attr('style','height: 0px;');
+    jQuery('#gridContainer4').find('.dojoxGridMasterView').attr('id','gridPonderation');
+    var target = document.getElementById('gridPonderation');
+    observer.observe(target, { attributes : true, attributeFilter : ['style'] });
+}
+
+// Keep grid only from loaded page
+function keep_grid_only(){
+    var grid_only = jQuery('#gridContainer4');
+    jQuery('#ponderation_grid').html(grid_only.html());
 }
 
 // Create Ponderation Grid
@@ -61,9 +117,6 @@ function create_div_pond_grid(){
 	
 	// Append grid
 	document.getElementsByTagName('body')[0].appendChild(pond_grid);
-    
-	// Debug in console
-	console.log("Ponderation Grid created");
 }
 
 // Show hide grid div && create it if not exist
@@ -75,7 +128,6 @@ function show_hide_ponderation(){
         btn_ponderation.innerHTML = "Afficher Grille des ponderations";
         document.getElementById('ponderation_grid').setAttribute('style','display: none');
 
-    
     //Hide
     }else{
         btn_ponderation.innerHTML = "Cacher grille des ponderations";

--- a/safari/safari.safariextension/data_funtions.js
+++ b/safari/safari.safariextension/data_funtions.js
@@ -1,0 +1,107 @@
+var data_ponderation;
+var btn_ponderation;
+var pond_grid;
+
+// Addon
+function addon_ponderation(){
+
+	// Grid ponderation
+	create_div_pond_grid();
+
+	// Btn : Get All Ponderation
+    btn_ponderation= document.createElement("button");
+    btn_ponderation.id = "btn_ponderation";
+    btn_ponderation.innerHTML = "Affiche toutes les ponderations";
+    btn_ponderation.classList.add("gel-glacial");
+    btn_ponderation.onclick = get_all_ponderation;
+
+	// Btns div
+    var div_btn = document.createElement("div");
+	div_btn.id = "btn_ponderation";
+    div_btn.classList.add("gel-glacial-bar");
+	div_btn.appendChild(btn_ponderation);
+	
+	// Insert btns group
+    document.body.insertBefore(div_btn,document.body.children[0]);
+}
+
+// Get Ponderation datas from url ponderation
+function get_all_ponderation(){
+
+    document.getElementById("gridContainer4").id = "gridNotes";
+
+    btn_ponderation.disabled = true;
+    btn_ponderation.innerHTML = "Load datas...";
+    var url = window.location.href;
+    url = url.replace("notesEtu.php", "ponderation.php");
+    $("#ponderation_grid").load(url,function(){
+        data_ponderation = data;
+		for (i = 0; i < data.length-1; i++) {
+			for (j = 0; j < countProperties(data[i])-1; j++) {
+				if(data[i][j] != ""){
+					if(typeof dataToolTip[i][j] != 'undefined'){
+						if(typeof dataToolTip[i][j].ponderation != 'undefined'){
+							dataToolTip[i][j].ponderation = data[i][j];
+						}
+					}
+				}
+			}
+		}
+        btn_ponderation.onclick = show_hide_ponderation;
+        btn_ponderation.disabled = false;
+        btn_ponderation.innerHTML = "Cacher grille des ponderations";
+        document.getElementById('ponderation_grid').setAttribute('style','display: block');
+	});
+}
+
+// Create Ponderation Grid
+function create_div_pond_grid(){
+	pond_grid = document.createElement('div');
+	pond_grid.id = "ponderation_grid";
+	
+	// Append grid
+	document.getElementsByTagName('body')[0].appendChild(pond_grid);
+    
+	// Debug in console
+	console.log("Ponderation Grid created");
+}
+
+// Show hide grid div && create it if not exist
+function show_hide_ponderation(){
+    var id = "ponderation_grid";
+    
+    // Show
+    if(document.getElementById(id).style.display=="block"){
+        btn_ponderation.innerHTML = "Afficher Grille des ponderations";
+        document.getElementById('ponderation_grid').setAttribute('style','display: none');
+
+    
+    //Hide
+    }else{
+        btn_ponderation.innerHTML = "Cacher grille des ponderations";
+        document.getElementById('ponderation_grid').setAttribute('style','display: block');
+    }
+    return true;
+}
+
+// Count number of elements in object
+function countProperties(obj) {
+    var count = 0;
+    for(var prop in obj) {
+        if(obj.hasOwnProperty(prop))
+            ++count;
+    }
+    return count;
+}
+
+// Exec
+function exec(){
+    var path = window.location.pathname;
+    var regex = /notesEtu\.php$/;
+    
+    //exec listeners base on there regex
+    if(regex.test(path)){
+        addon_ponderation();
+    }
+}
+exec();

--- a/safari/safari.safariextension/main.js
+++ b/safari/safari.safariextension/main.js
@@ -6,6 +6,7 @@ function safari_load_addons(){
 	addons.push({
 		"regex_path"  : /.*\.usherbrooke\.ca\/.*\/notesEtu\.php/,
 		"addon_path"  : "addons/marks.js",
+        "addon_data"  : "data_funtions.js",
         "lib_path"    : "lib/external/jquery-2.1.4.min.js",
 		"style_path"  : "style.css",
 	});
@@ -16,6 +17,7 @@ function safari_exec_addons(){
 		if(addon.regex_path.test(window.location.href)){
             inject_script(addon.lib_path);
 			inject_script(addon.addon_path);
+            inject_script(addon.addon_data);
 		}
 	})
 }
@@ -32,9 +34,3 @@ jQuery(window).load(function(){
     safari_load_addons();
     safari_exec_addons();
 });
-
-
-
-
-
-


### PR DESCRIPTION
Version stable du bouton pondération:

La page des pondérations est loader à partir de la page des notes quand l'utilisateur clique sur ce bouton. 

Lorsque la page est loader: une fonction de type "observer" attend que la grille actualisée (le de dojoxGridMasterView change).

Lorsque le style est changé : le div de "dojoxGridMasterView" est attribué au nouveau Div id: "ponderation_grid".

L'utilisateur peut alors choisir d'afficher la grille des pondérations ou de la cacher.

Les pondérations manquantes sont ajoutées dans les infobulles de la grille de note.
