### PR TITLE
Incrémentation des numéros de version pour se préparer au release 0.0.2

### DIFF
--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Gel-Glacial",
     "description": "Pour améliorer le site de Génie Élec-Info",
-    "version": "1.0",
+    "version": "0.0.2",
     
     "browser_action": {
         "default_icon": "icon.png",

--- a/firefox/package.json
+++ b/firefox/package.json
@@ -1,7 +1,7 @@
 {
   "title": "Gel Glacial",
   "name": "gelglacial",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pour améliorer l'interface de gel.usherbrooke.ca",
   "main": "index.js",
   "author": "Antoine Morin-Paulhus",


### PR DESCRIPTION
J'ai incrémenté les numéros de version dans les manifest pour préparer notre prochain release. J'ai aussi créé un compte chez Mozilla pour signer nos xpi pour Firefox.
